### PR TITLE
Set read_only true if flags contains RDONLY

### DIFF
--- a/src/mount.rs
+++ b/src/mount.rs
@@ -215,7 +215,10 @@ impl Mount {
                 }
 
                 let new_loopback = loopdev::LoopControl::open()?.next_free()?;
-                new_loopback.attach_file(source)?;
+                new_loopback
+                    .with()
+                    .read_only(flags.contains(MountFlags::RDONLY))
+                    .attach(source)?;
                 let path = new_loopback.path().expect("loopback does not have path");
                 c_source = Some(to_cstring(path.as_os_str().as_bytes())?);
                 loop_path = Some(path);


### PR DESCRIPTION
When the file being mounted (bind mount) is on a read-only file system, the read_only flag must be set, otherwise an attempt is made to open the source file in RW mode, which results in an error.