### PR TITLE
Add ability to specify an offset for mounting loopback devices

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,6 +21,7 @@ pub struct MountBuilder<'a> {
     #[default(MountFlags::empty())]
     flags: MountFlags,
     fstype: Option<FilesystemType<'a>>,
+    loopback_offset: Option<u64>,
     data: Option<&'a str>,
 }
 
@@ -43,12 +44,20 @@ impl<'a> MountBuilder<'a> {
         self
     }
 
+    ///Offset for the loopback device
+    #[cfg(feature = "loop")]
+    pub fn loopback_offset(mut self, offset: u64) -> Self {
+        self.loopback_offset = Some(offset);
+        self
+    }
+
     /// Mount the `source` to the `target`.
     pub fn mount(self, source: impl AsRef<Path>, target: impl AsRef<Path>) -> io::Result<Mount> {
         let MountBuilder {
             data,
             fstype,
             flags,
+            loopback_offset,
         } = self;
 
         let supported;
@@ -61,7 +70,7 @@ impl<'a> MountBuilder<'a> {
             }
         };
 
-        Mount::new(source, target, fstype, flags, data)
+        Mount::new(source, target, fstype, flags, loopback_offset, data)
     }
 
     /// Perform a mount which auto-unmounts on drop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn scoped_mount<T, S: FnOnce() -> T>(
 ) -> Result<T, ScopedMountError> {
     let supported = SupportedFilesystems::new().map_err(ScopedMountError::Supported)?;
 
-    Mount::new(&source, mount_at, &supported, MountFlags::empty(), None)
+    Mount::new(&source, mount_at, &supported, MountFlags::empty(), None, None)
         .map_err(ScopedMountError::Mount)?;
 
     let result = scope();

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -182,6 +182,7 @@ impl Mount {
         target: T,
         fstype: F,
         mut flags: MountFlags,
+        loopback_offset: Option<u64>,
         data: Option<&str>,
     ) -> io::Result<Self>
     where
@@ -218,6 +219,7 @@ impl Mount {
                 new_loopback
                     .with()
                     .read_only(flags.contains(MountFlags::RDONLY))
+                    .offset(loopback_offset.unwrap_or(0u64))
                     .attach(source)?;
                 let path = new_loopback.path().expect("loopback does not have path");
                 c_source = Some(to_cstring(path.as_os_str().as_bytes())?);


### PR DESCRIPTION
I found that if you want to mount a loopback device with an offset it has to be specified when the loopback device is being attached. I added some option to do this and it seems to work well for my use case. I thought I'd submit it for consideration.