### PR TITLE
Make loopdev optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 bitflags = "1.3.2"
 libc = "0.2.137"
-loopdev = "0.4.0"
+loopdev = { version = "0.4.0", optional = true }
 smart-default = "0.6.0"
 thiserror = "1.0.37"
 tracing = "0.1.37"
 
 [dev-dependencies]
 clap = "4.0.18"
+
+[features]
+default = ["loop"]
+loop = ["loopdev"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
 //! }
 
 extern crate libc;
-extern crate loopdev;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -15,6 +15,7 @@ use std::{
 pub struct Mount {
     pub(crate) target: CString,
     pub(crate) fstype: String,
+    #[cfg(feature = "loop")]
     pub(crate) loopback: Option<loopdev::LoopDevice>,
     pub(crate) loop_path: Option<std::path::PathBuf>,
 }
@@ -25,6 +26,7 @@ impl Unmount for Mount {
             unmount_(self.target.as_ptr(), flags)?;
         }
 
+        #[cfg(feature = "loop")]
         if let Some(ref loopback) = self.loopback {
             loopback.detach()?;
         }
@@ -99,6 +101,7 @@ impl Mount {
         Mount {
             target,
             fstype,
+            #[cfg(feature = "loop")]
             loopback: None,
             loop_path: None,
         }


### PR DESCRIPTION
sys-mount 2 started requiring loopdev. Support omitting it again, which
saves 28 dependencies.
