### PR TITLE
Make `MountBuilder` `Copy`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,7 +22,7 @@ use std::ptr;
 ///     Ok(())
 /// }
 /// ```
-#[derive(smart_default::SmartDefault)]
+#[derive(Clone, Copy, smart_default::SmartDefault)]
 #[allow(clippy::module_name_repetitions)]
 pub struct MountBuilder<'a> {
     #[default(MountFlags::empty())]

--- a/src/fstype.rs
+++ b/src/fstype.rs
@@ -4,7 +4,7 @@
 use crate::supported::SupportedFilesystems;
 
 /// Defines how the file system type should be derived for a mount -- auto or manual
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum FilesystemType<'a> {
     /// The automatic variant will iterate through a list of pre-generated supported
     /// file systems, and attempt to mount each one before giving up.


### PR DESCRIPTION
This makes it easier to make a series of mounts with similar options, by
reusing the builder.
