### PR TITLE
feat: Add option for explicit loopback

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use libc::mount;
 use std::ptr;
-use loopdev::LoopDevice;
 
 /// Builder API for mounting devices
 ///
@@ -144,7 +143,7 @@ impl<'a> MountBuilder<'a> {
 
         if !source.as_os_str().is_empty() {
             #[cfg(feature = "loop")]
-            let mut create_loopback = |flags: &MountFlags| -> io::Result<LoopDevice> {
+            let mut create_loopback = |flags: &MountFlags| -> io::Result<loopdev::LoopDevice> {
                 let new_loopback = loopdev::LoopControl::open()?.next_free()?;
                 new_loopback
                     .with()


### PR DESCRIPTION
I have an image with _EXT4_ file system and the only way to mount is to use a loopback device. But `sys-mount` only mounts a device with loopback if it's an _ISO_ or _SquashFS_. 
This PR adds an option to explicitly mount with a loopback device.