### PR TITLE
Implemented umount path agnostically, updated dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ edition = "2021"
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.4.1"
 libc = "0.2.139"
 loopdev = { version = "0.4.0", optional = true }
-smart-default = "0.6.0"
+proc-mounts = "0.3.0"
+smart-default = "0.7.1"
 thiserror = "1.0.38"
 tracing = "0.1.37"
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -9,6 +9,7 @@ use libc::{
 
 bitflags! {
     /// Flags which may be specified when mounting a file system.
+    #[derive(Copy, Clone)]
     pub struct MountFlags: c_ulong {
         /// Perform a bind mount, making a file or a directory subtree visible at another
         /// point within a file system. Bind mounts may cross file system boundaries and
@@ -95,6 +96,7 @@ bitflags! {
 
 bitflags! {
     /// Flags which may be specified when unmounting a file system.
+    #[derive(Copy, Clone)]
     pub struct UnmountFlags: c_int {
         /// Force unmount even if busy. This can cause data loss. (Only for NFS mounts.)
         const FORCE = MNT_FORCE;


### PR DESCRIPTION
Updated the way umount works, so it now uses the `proc_mount` crate to find whether it has been passed the source or destination of a mounted filesystem and pass the correct details to the underlying umount2 call, this addresses issue #1.

I also just did a quick update of the dependencies. The only change required was to derive clone and copy on the flags, as `bitflag` stopped doing a lot of default derives.