### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sys-mount"
-version = "2.1.0"
+version = "3.0.0"
 description = "High level FFI binding around the sys mount & umount2 calls"
 repository = "https://github.com/pop-os/sys-mount"
 authors = ["Michael Aaron Murphy <michael@mmurphy.dev>"]
@@ -13,7 +13,7 @@ edition = "2021"
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.4.1"
 libc = "0.2.139"
 loopdev = { version = "0.4.0", optional = true }
 smart-default = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "passively-maintained" }
 bitflags = "1.3.2"
 libc = "0.2.139"
 loopdev = { version = "0.4.0", optional = true }
-smart-default = "0.6.0"
+smart-default = "0.7.1"
 thiserror = "1.0.38"
 tracing = "0.1.37"
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -9,6 +9,7 @@ use libc::{
 
 bitflags! {
     /// Flags which may be specified when mounting a file system.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct MountFlags: c_ulong {
         /// Perform a bind mount, making a file or a directory subtree visible at another
         /// point within a file system. Bind mounts may cross file system boundaries and
@@ -95,6 +96,7 @@ bitflags! {
 
 bitflags! {
     /// Flags which may be specified when unmounting a file system.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct UnmountFlags: c_int {
         /// Force unmount even if busy. This can cause data loss. (Only for NFS mounts.)
         const FORCE = MNT_FORCE;


### PR DESCRIPTION
This upgrades the dependencies of sys-mount to current versions. In particular,
this removes an indirect dependency on syn 1 (with corresponding performance
hit for crates that otherwise only need syn 2), and upgrades to bitflags 2
which has substantial updates.

- Upgrade to smart-default 0.7.1 to use syn 2
- Upgrade to bitflags 2.4.1
