### PR TITLE
fix: only automatically create loopback for .squashfs and .iso

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -169,9 +169,8 @@ impl<'a> MountBuilder<'a> {
                         flags |= MountFlags::RDONLY;
                         FilesystemType::Manual("squashfs")
                     };
+                    loopback = Some(create_loopback(&flags)?);
                 }
-
-                loopback = Some(create_loopback(&flags)?);
             }
 
             #[cfg(feature = "loop")]


### PR DESCRIPTION
Builder used to errornously create loopback devices for mounts when the mounted file contained any extension.

Fix it to only automatically create loopback for files with .squashfs and .iso extensions.

Fixes #35 